### PR TITLE
Add ngOnDestroy to typings to enable inheritance

### DIFF
--- a/typings/angular2-meteor.d.ts
+++ b/typings/angular2-meteor.d.ts
@@ -7,6 +7,7 @@ declare module ngMeteor {
     subscribe(name: string, ...rest: any[]): Meteor.SubscriptionHandle;
     autorun(runFunc: Function, autoBind?: boolean): Tracker.Computation;
     call(name: string, ...rest: any[]);
+    ngOnDestroy():void;
   }
 
   function bootstrap(appComponentType: /*Type*/ any, bindings?: Array<core.Type | core.Provider | any[]>): Promise<core.ApplicationRef>;


### PR DESCRIPTION
This is to support inheriting from MeteorComponent. If you extend MeteorComponent, need to implement your own ngOnDestroy, and don’t call this ngOnDestroy you end up leaking via the autoruns and subscriptions, as well as those keep running unnecessarily.