### PR TITLE
bugfix(change-detection): Fixed changes detection issue

### DIFF
--- a/build/mongo_cursor_differ.js
+++ b/build/mongo_cursor_differ.js
@@ -79,7 +79,7 @@ var MongoCursorDiffer = (function (_super) {
             this._curObserver = this._obsFactory.create(cursor);
             this._subscription = async_1.ObservableWrapper.subscribe(this._curObserver, function (changes) {
                 // Run it outside Angular2 zone to cause running diff one more time and apply changes.
-                _this._zone.runOutsideAngular(function () { return _this._updateLatestValue(changes); });
+                _this._zone.run(function () { return _this._updateLatestValue(changes); });
             });
         }
         if (this._lastChanges) {

--- a/build/mongo_cursor_differ.js
+++ b/build/mongo_cursor_differ.js
@@ -28,7 +28,9 @@ var MongoCursorDifferFactory = (function (_super) {
     function MongoCursorDifferFactory() {
         _super.apply(this, arguments);
     }
-    MongoCursorDifferFactory.prototype.supports = function (obj) { return checkIfMongoCursor(obj); };
+    MongoCursorDifferFactory.prototype.supports = function (obj) {
+        return checkIfMongoCursor(obj);
+    };
     MongoCursorDifferFactory.prototype.create = function (cdRef) {
         return new MongoCursorDiffer(cdRef, new MongoCursorObserverFactory());
     };
@@ -79,7 +81,11 @@ var MongoCursorDiffer = (function (_super) {
             this._curObserver = this._obsFactory.create(cursor);
             this._subscription = async_1.ObservableWrapper.subscribe(this._curObserver, function (changes) {
                 // Run it outside Angular2 zone to cause running diff one more time and apply changes.
-                _this._zone.run(function () { return _this._updateLatestValue(changes); });
+                _this._zone.runOutsideAngular(function () {
+                    var retVal = _this._updateLatestValue(changes);
+                    _this._zone.run(function () { });
+                    return retVal;
+                });
             });
         }
         if (this._lastChanges) {

--- a/modules/mongo_cursor_differ.ts
+++ b/modules/mongo_cursor_differ.ts
@@ -102,7 +102,7 @@ export class MongoCursorDiffer extends DefaultIterableDiffer {
       this._subscription = ObservableWrapper.subscribe(this._curObserver,
         changes => {
           // Run it outside Angular2 zone to cause running diff one more time and apply changes.
-          this._zone.runOutsideAngular(() => this._updateLatestValue(changes));
+          this._zone.run(() => this._updateLatestValue(changes));
         });
     }
 

--- a/package.json
+++ b/package.json
@@ -25,15 +25,10 @@
     "test": "./run_tests.sh"
   },
   "peerDependencies": {
-    "angular2": "^2.0.0-beta.17",
-    "es6-shim": "^0.35.0",
-    "zone.js": "^0.6.10",
-    "rxjs": "5.0.0-beta.6",
-    "reflect-metadata": "0.1.2"
+    "angular2": "^2.0.0-beta.17"
   },
   "devDependencies": {
     "angular2": "^2.0.0-beta.17",
-    "es6-shim": "^0.35.0",
     "ghooks": "^1.2.1",
     "validate-commit-msg": "^2.6.1",
     "gulp": "^3.9.1",
@@ -41,14 +36,11 @@
     "gulp-git": "^1.7.0",
     "gulp-tslint": "^4.3.4",
     "gulp-typings": "^1.3.0",
-    "reflect-metadata": "0.1.2",
     "run-sequence": "^1.1.5",
-    "rxjs": "5.0.0-beta.6",
     "tsc": "^1.20150623.0",
     "tslint": "^3.6.0",
     "typescript": "^1.7.5",
-    "typings": "^0.7.7",
-    "zone.js": "^0.6.10"
+    "typings": "^0.7.7"
   },
   "dependencies": {
     "meteor-promise": "^0.6.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "reflect-metadata": "0.1.2"
   },
   "devDependencies": {
-    "angular2": "^2.0.0-beta.16",
+    "angular2": "^2.0.0-beta.17",
     "es6-shim": "^0.35.0",
     "ghooks": "^1.2.1",
     "validate-commit-msg": "^2.6.1",
@@ -43,7 +43,7 @@
     "gulp-typings": "^1.3.0",
     "reflect-metadata": "0.1.2",
     "run-sequence": "^1.1.5",
-    "rxjs": "5.0.0-beta.2",
+    "rxjs": "5.0.0-beta.6",
     "tsc": "^1.20150623.0",
     "tslint": "^3.6.0",
     "typescript": "^1.7.5",

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,6 @@
 {
   "rules": {
-    "align": [true, "parameters"],
+    "align": false,
     "class-name": true,
     "comment-format": [true, "check-uppercase", "check-space"],
     "curly": true,
@@ -11,11 +11,7 @@
     "label-undefined": true,
     "max-line-length": [true, 100],
     "member-access": false,
-    "member-ordering": [true,
-      "public-before-private",
-      "static-before-instance",
-      "variables-before-functions"
-    ],
+    "member-ordering": false,
     "no-arg": true,
     "no-bitwise": true,
     "no-console": [true,

--- a/tslint.json
+++ b/tslint.json
@@ -25,13 +25,13 @@
     "no-debugger": true,
     "no-duplicate-key": true,
     "no-duplicate-variable": true,
-    "no-empty": true,
+    "no-empty": false,
     "no-eval": true,
     "no-inferrable-types": true,
     "no-shadowed-variable": true,
     "no-string-literal": true,
     "no-switch-case-fall-through": true,
-    "no-trailing-whitespace": true,
+    "no-trailing-whitespace": false,
     "no-unused-expression": true,
     "no-unused-variable": true,
     "no-unreachable": true,
@@ -42,8 +42,7 @@
     "one-line": [true,
       "check-open-brace",
       "check-catch",
-      "check-else",
-      "check-whitespace"
+      "check-else"
     ],
     "quotemark": [true, "single"],
     "radix": true,
@@ -53,13 +52,7 @@
       "check-format",
       "allow-leading-underscore"
     ],
-    "whitespace": [true,
-      "check-branch",
-      "check-decl",
-      "check-operator",
-      "check-separator",
-      "check-type"
-    ],
+    "whitespace": false,
     "use-strict": [true, "check-module"]
   }
 }


### PR DESCRIPTION
The changes was not visible until zone run triggers. 
In an empty application without any zone triggers, the app does not show any data due this. 
If we want the change detection to run diff again and trigger the "_applyChanges" method, we need to use `run` instead of `runOutsideAngular`.

Can be reproduced with Meteor-Angular2.0-Socially step 3.9 (https://github.com/Urigo/meteor-angular2.0-socially/commit/829b9b7819a3440cc5b0da085713f4b4be192d8d)

@barbatus @Urigo 