### PR TITLE
"#" inside of expressions is deprecated. Change template in todo example

### DIFF
--- a/examples/todos-meteor-1.3/client/components/task-list.html
+++ b/examples/todos-meteor-1.3/client/components/task-list.html
@@ -1,5 +1,5 @@
 <div *ngIf="!isLoading">
-  <ul *ngFor="#task of tasks">
+  <ul *ngFor="let task of tasks">
     <task [data]="task"></task>
   </ul>
 </div>


### PR DESCRIPTION
Inside of structural directives that declare local variables, such as *ngFor, usage of #... is deprecated. Use let instead.

Template parse warnings:
Angular 2.0.0-beta.17 (2016-04-28):
"#" inside of expressions is deprecated. Use "let" instead! ("<div *ngIf="!isLoading">
  <ul [ERROR ->]*ngFor="#task of tasks">
    <task [data]="task"></task>
  </ul>
"): TaskList@1:6