### PR TITLE
Adding @angular/common as a peerDependency will fix some initial setup issues when trying to import from @angular/common

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "peerDependencies": {
     "@angular/core": "2.0.0-rc.1",
+    "@angular/common": "2.0.0-rc.1",
     "es6-shim": "^0.35.0",
     "zone.js": "^0.6.12",
     "rxjs": "5.0.0-beta.6",


### PR DESCRIPTION
When following the tutorial i noticed that i couldn't import from @angular/common without manually installing the dependency. Adding @angular/common should install it as a dependency.