### PR TITLE
Loosen npm version constraint for reflect-metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "es6-shim": "^0.35.0",
     "zone.js": "^0.6.12",
     "rxjs": "5.0.0-beta.6",
-    "reflect-metadata": "0.1.2",
+    "reflect-metadata": "^0.1.2",
     "ghooks": "^1.2.1",
     "validate-commit-msg": "^2.6.1",
     "gulp": "^3.9.1",


### PR DESCRIPTION
Got peer dependency errors running angular-meteor-socially because of reflect-metadata version 0.1.3. Loosened the constraint. Ignore this if there's a specific reason version 0.1.2 was set fixed.