### PR TITLE
Update tutorial example to prevent #318

### DIFF
--- a/examples/todos-meteor-1.3/tsconfig.json
+++ b/examples/todos-meteor-1.3/tsconfig.json
@@ -16,5 +16,7 @@
   ],
   "exclude": [
     "node_modules"
-  ]
+  ],
+  "compileOnSave": false,
+  "buildOnSave": false
 }


### PR DESCRIPTION
Prevents IDEs/text editors to compile typescript files themselves, so there are no conflicts with Meteor.

#318 is a bit annoying for begginers as the solution is very hard to figure out given the symptoms ("Collection already defined" for example), adding those extra lines would prevent some headaches.