### PR TITLE
chore(observavles): Added ObservableMeteorSubscription and Observable…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 typings
 atmosphere-packages/examples
 .npm
+npm-debug.log

--- a/dist/minimongo-observable/index.d.ts
+++ b/dist/minimongo-observable/index.d.ts
@@ -1,3 +1,5 @@
 export * from './observable-collection';
 export * from './to-observable';
 export * from './meteor-observable';
+export * from './observable-cursor';
+export * from './observable-subscription';

--- a/dist/minimongo-observable/index.js
+++ b/dist/minimongo-observable/index.js
@@ -5,3 +5,5 @@ function __export(m) {
 __export(require('./observable-collection'));
 __export(require('./to-observable'));
 __export(require('./meteor-observable'));
+__export(require('./observable-cursor'));
+__export(require('./observable-subscription'));

--- a/dist/minimongo-observable/meteor-observable.d.ts
+++ b/dist/minimongo-observable/meteor-observable.d.ts
@@ -1,5 +1,6 @@
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs';
+import { ObservableMeteorSubscription } from './observable-subscription';
 export declare class MeteorObservable {
     static call<T>(name: string, ...args: any[]): Observable<T>;
-    static subscribe<T>(name: string, ...args: any[]): Observable<T>;
+    static subscribe<T>(name: string, ...args: any[]): ObservableMeteorSubscription<T>;
 }

--- a/dist/minimongo-observable/meteor-observable.js
+++ b/dist/minimongo-observable/meteor-observable.js
@@ -1,5 +1,6 @@
 "use strict";
-var Rx_1 = require('rxjs/Rx');
+var rxjs_1 = require('rxjs');
+var observable_subscription_1 = require('./observable-subscription');
 var _ = require('lodash');
 var MeteorObservable = (function () {
     function MeteorObservable() {
@@ -14,7 +15,7 @@ var MeteorObservable = (function () {
         if (lastParam && _.isFunction(lastParam)) {
             throw new Error("Invalid MeteorObservable.call arguments:\n         Your last param can't be a callback function, \n         please remove it and use \".subscribe\" of the Observable!");
         }
-        return Rx_1.Observable.create(function (observer) {
+        return rxjs_1.Observable.create(function (observer) {
             Meteor.call.apply(Meteor, argumentsArray.concat([
                 function (error, result) {
                     if (error) {
@@ -39,7 +40,7 @@ var MeteorObservable = (function () {
         if (lastParam && _.isObject(lastParam) && (lastParam.onReady || lastParam.onError)) {
             throw new Error("Invalid MeteorObservable.subscribe arguments: \n        your last param can't be a callbacks object, \n        please remove it and use \".subscribe\" of the Observable!");
         }
-        return Rx_1.Observable.create(function (observer) {
+        var observable = observable_subscription_1.ObservableMeteorSubscription.create(function (observer) {
             var handle = Meteor.subscribe.apply(Meteor, argumentsArray.concat([
                 {
                     onError: function (error) {
@@ -51,6 +52,7 @@ var MeteorObservable = (function () {
                     }
                 }
             ]));
+            observable._meteorSubscriptionRef = handle;
             return function () {
                 if (handle && handle.stop) {
                     try {
@@ -61,6 +63,7 @@ var MeteorObservable = (function () {
                 }
             };
         });
+        return observable;
     };
     return MeteorObservable;
 }());

--- a/dist/minimongo-observable/observable-collection.d.ts
+++ b/dist/minimongo-observable/observable-collection.d.ts
@@ -1,9 +1,9 @@
-import { Observable } from 'rxjs/Rx';
 import Selector = Mongo.Selector;
 import ObjectID = Mongo.ObjectID;
 import SortSpecifier = Mongo.SortSpecifier;
 import FieldSpecifier = Mongo.FieldSpecifier;
 import Modifier = Mongo.Modifier;
+import { ObservableCursor } from './observable-cursor';
 export declare module MongoObservable {
     interface ConstructorOptions {
         connection?: Object;
@@ -44,7 +44,7 @@ export declare module MongoObservable {
             fields?: FieldSpecifier;
             reactive?: boolean;
             transform?: Function;
-        }): Observable<Array<T>>;
+        }): ObservableCursor<Array<T>>;
         findOne(selector?: Selector | ObjectID | string, options?: {
             sort?: SortSpecifier;
             skip?: number;

--- a/dist/minimongo-observable/observable-cursor.d.ts
+++ b/dist/minimongo-observable/observable-cursor.d.ts
@@ -1,0 +1,12 @@
+import { Observable, Subscriber } from 'rxjs';
+export declare class ObservableCursor<T> extends Observable<T> {
+    _cursorRef: any;
+    _reloadRef: any;
+    private _isReactive;
+    static create(subscribe?: <R>(subscriber: Subscriber<R>) => any): ObservableCursor<{}>;
+    constructor(subscribe?: <R>(subscriber: Subscriber<R>) => any);
+    nonReactive(): ObservableCursor<T>;
+    isReactive(): boolean;
+    getMongoCursor(): Mongo.Cursor<T>;
+    reload(): ObservableCursor<T>;
+}

--- a/dist/minimongo-observable/observable-cursor.js
+++ b/dist/minimongo-observable/observable-cursor.js
@@ -1,0 +1,38 @@
+"use strict";
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+var rxjs_1 = require('rxjs');
+var ObservableCursor = (function (_super) {
+    __extends(ObservableCursor, _super);
+    function ObservableCursor(subscribe) {
+        _super.call(this, subscribe);
+        this._isReactive = true;
+    }
+    ObservableCursor.create = function (subscribe) {
+        return new ObservableCursor(subscribe);
+    };
+    ObservableCursor.prototype.nonReactive = function () {
+        this._isReactive = false;
+        return this;
+    };
+    ObservableCursor.prototype.isReactive = function () {
+        return this._isReactive;
+    };
+    ObservableCursor.prototype.getMongoCursor = function () {
+        return this._cursorRef;
+    };
+    ObservableCursor.prototype.reload = function () {
+        if (!this.isReactive() && this._reloadRef) {
+            this._reloadRef();
+            return this;
+        }
+        else {
+            throw new Error("\"reload\" method only available when using non-reactive Observable Mongo.Cursor!");
+        }
+    };
+    return ObservableCursor;
+}(rxjs_1.Observable));
+exports.ObservableCursor = ObservableCursor;

--- a/dist/minimongo-observable/observable-subscription.d.ts
+++ b/dist/minimongo-observable/observable-subscription.d.ts
@@ -1,0 +1,7 @@
+import { Observable, Subscriber } from 'rxjs';
+export declare class ObservableMeteorSubscription<T> extends Observable<T> {
+    _meteorSubscriptionRef: Meteor.SubscriptionHandle;
+    static create(subscribe?: <R>(subscriber: Subscriber<R>) => any): ObservableMeteorSubscription<{}>;
+    constructor(subscribe?: <R>(subscriber: Subscriber<R>) => any);
+    stop(): void;
+}

--- a/dist/minimongo-observable/observable-subscription.js
+++ b/dist/minimongo-observable/observable-subscription.js
@@ -1,0 +1,23 @@
+"use strict";
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+var rxjs_1 = require('rxjs');
+var ObservableMeteorSubscription = (function (_super) {
+    __extends(ObservableMeteorSubscription, _super);
+    function ObservableMeteorSubscription(subscribe) {
+        _super.call(this, subscribe);
+    }
+    ObservableMeteorSubscription.create = function (subscribe) {
+        return new ObservableMeteorSubscription(subscribe);
+    };
+    ObservableMeteorSubscription.prototype.stop = function () {
+        if (this._meteorSubscriptionRef && this._meteorSubscriptionRef.stop) {
+            this._meteorSubscriptionRef.stop();
+        }
+    };
+    return ObservableMeteorSubscription;
+}(rxjs_1.Observable));
+exports.ObservableMeteorSubscription = ObservableMeteorSubscription;

--- a/dist/minimongo-observable/to-observable.d.ts
+++ b/dist/minimongo-observable/to-observable.d.ts
@@ -1,2 +1,2 @@
-import { Observable } from 'rxjs/Rx';
-export declare function toObservable<T>(cursor: Mongo.Cursor<T>): Observable<Array<T>>;
+import { ObservableCursor } from './observable-cursor';
+export declare function toObservable<T>(cursor: Mongo.Cursor<T>): ObservableCursor<Array<T>>;

--- a/dist/minimongo-observable/to-observable.js
+++ b/dist/minimongo-observable/to-observable.js
@@ -1,18 +1,30 @@
 "use strict";
-var Rx_1 = require('rxjs/Rx');
+var observable_cursor_1 = require('./observable-cursor');
 function toObservable(cursor) {
-    return Rx_1.Observable.create(function (observer) {
+    var observable = observable_cursor_1.ObservableCursor.create(function (observer) {
         var handleChange = function () {
             observer.next(cursor.fetch());
         };
-        var handler = cursor.observe({
-            added: handleChange,
-            changed: handleChange,
-            removed: handleChange
-        });
+        var handler;
+        var isReactive = observable.isReactive();
+        observable._cursorRef = cursor;
+        observable._reloadRef = handleChange;
+        if (isReactive) {
+            handler = cursor.observe({
+                added: handleChange,
+                changed: handleChange,
+                removed: handleChange
+            });
+        }
+        else {
+            handleChange();
+        }
         return function () {
-            handler.stop();
+            if (isReactive && handler && handler.stop) {
+                handler.stop();
+            }
         };
     });
+    return observable;
 }
 exports.toObservable = toObservable;

--- a/modules/minimongo-observable/index.ts
+++ b/modules/minimongo-observable/index.ts
@@ -1,3 +1,5 @@
 export * from './observable-collection';
 export * from './to-observable';
 export * from './meteor-observable';
+export * from './observable-cursor';
+export * from './observable-subscription';

--- a/modules/minimongo-observable/meteor-observable.ts
+++ b/modules/minimongo-observable/meteor-observable.ts
@@ -1,4 +1,5 @@
-import {Observable, Subscriber} from 'rxjs/Rx';
+import {Observable, Subscriber} from 'rxjs';
+import {ObservableMeteorSubscription} from './observable-subscription';
 import * as _ from 'lodash';
 
 export class MeteorObservable {
@@ -28,7 +29,7 @@ export class MeteorObservable {
     });
   }
 
-  public static subscribe<T>(name: string, ...args: any[]): Observable<T> {
+  public static subscribe<T>(name: string, ...args: any[]): ObservableMeteorSubscription<T> {
     const argumentsArray: Array<any> = Array.prototype.slice.call(arguments);
     const lastParam = argumentsArray[argumentsArray.length - 1];
 
@@ -39,7 +40,8 @@ export class MeteorObservable {
         please remove it and use ".subscribe" of the Observable!`);
     }
 
-    return Observable.create((observer: Subscriber<Meteor.Error | T>) => {
+    const observable =
+      ObservableMeteorSubscription.create((observer: Subscriber<Meteor.Error | T>) => {
       let handle = Meteor.subscribe.apply(Meteor, argumentsArray.concat([
         {
           onError: (error: Meteor.Error) => {
@@ -52,6 +54,8 @@ export class MeteorObservable {
         }
       ]));
 
+      observable._meteorSubscriptionRef = handle;
+
       return () => {
         if (handle && handle.stop) {
           try {
@@ -62,5 +66,7 @@ export class MeteorObservable {
         }
       };
     });
+
+    return <ObservableMeteorSubscription<T>>observable;
   }
 }

--- a/modules/minimongo-observable/observable-collection.ts
+++ b/modules/minimongo-observable/observable-collection.ts
@@ -1,10 +1,10 @@
-import {Observable} from 'rxjs/Rx';
 import Selector = Mongo.Selector;
 import ObjectID = Mongo.ObjectID;
 import SortSpecifier = Mongo.SortSpecifier;
 import FieldSpecifier = Mongo.FieldSpecifier;
 import Modifier = Mongo.Modifier;
 import {toObservable} from './to-observable';
+import {ObservableCursor} from './observable-cursor';
 
 export module MongoObservable {
   'use strict';
@@ -89,7 +89,7 @@ export module MongoObservable {
       fields ? : FieldSpecifier;
       reactive ? : boolean;
       transform ? : Function;
-    }) : Observable<Array<T>> {
+    }) : ObservableCursor<Array<T>> {
       const cursor = this.collection.find.apply(this.collection, arguments);
 
       return toObservable<T>(cursor);

--- a/modules/minimongo-observable/observable-cursor.ts
+++ b/modules/minimongo-observable/observable-cursor.ts
@@ -1,0 +1,41 @@
+import {Observable, Subscriber} from 'rxjs';
+
+export class ObservableCursor<T> extends Observable<T> {
+  public _cursorRef;
+  public _reloadRef;
+  private _isReactive : boolean = true;
+
+  static create(subscribe?: <R>(subscriber: Subscriber<R>) => any) {
+    return new ObservableCursor(subscribe);
+  }
+
+  constructor(subscribe?: <R>(subscriber: Subscriber<R>) => any) {
+    super(subscribe);
+  }
+
+  public nonReactive() : ObservableCursor<T> {
+    this._isReactive = false;
+
+    return this;
+  }
+
+  public isReactive() : boolean {
+    return this._isReactive;
+  }
+
+  public getMongoCursor() : Mongo.Cursor<T> {
+    return this._cursorRef;
+  }
+
+  public reload() : ObservableCursor<T> {
+    if (!this.isReactive() && this._reloadRef) {
+      this._reloadRef();
+
+      return this;
+    } else {
+      throw new Error(
+        `"reload" method only available when using non-reactive Observable Mongo.Cursor!`
+      );
+    }
+  }
+}

--- a/modules/minimongo-observable/observable-subscription.ts
+++ b/modules/minimongo-observable/observable-subscription.ts
@@ -1,0 +1,19 @@
+import {Observable, Subscriber} from 'rxjs';
+
+export class ObservableMeteorSubscription<T> extends Observable<T> {
+  public _meteorSubscriptionRef : Meteor.SubscriptionHandle;
+
+  static create(subscribe?: <R>(subscriber: Subscriber<R>) => any) {
+    return new ObservableMeteorSubscription(subscribe);
+  }
+
+  constructor(subscribe?: <R>(subscriber: Subscriber<R>) => any) {
+    super(subscribe);
+  }
+
+  stop() {
+    if (this._meteorSubscriptionRef && this._meteorSubscriptionRef.stop) {
+      this._meteorSubscriptionRef.stop();
+    }
+  }
+}

--- a/modules/minimongo-observable/to-observable.ts
+++ b/modules/minimongo-observable/to-observable.ts
@@ -1,19 +1,34 @@
-import {Observable, Subscriber} from 'rxjs/Rx';
+import {Subscriber} from 'rxjs/Rx';
+import {ObservableCursor} from './observable-cursor';
 
-export function toObservable<T>(cursor : Mongo.Cursor<T>) : Observable<Array<T>> {
-  return Observable.create((observer : Subscriber<Array<T>>) => {
+export function toObservable<T>(cursor : Mongo.Cursor<T>) : ObservableCursor<Array<T>> {
+  const observable =
+      ObservableCursor.create((observer : Subscriber<Array<T>>) => {
     const handleChange = () => {
       observer.next(cursor.fetch());
     };
 
-    let handler = cursor.observe({
-      added: handleChange,
-      changed: handleChange,
-      removed: handleChange
-    });
+    let handler;
+    let isReactive = observable.isReactive();
+    observable._cursorRef = cursor;
+    observable._reloadRef = handleChange;
+
+    if (isReactive) {
+      handler = cursor.observe({
+        added: handleChange,
+        changed: handleChange,
+        removed: handleChange
+      });
+    } else {
+      handleChange();
+    }
 
     return () => {
-      handler.stop();
+      if (isReactive && handler && handler.stop) {
+        handler.stop();
+      }
     };
   });
+
+  return <ObservableCursor<Array<T>>>observable;
 }

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -5,7 +5,7 @@ mv -f .node_modules node_modules
 npm run build
 mv -f node_modules .node_modules
 cd tests
-meteor npm install
+#meteor npm install
 linklocal
 meteor add practicalmeteor:mocha
 meteor test --driver-package=practicalmeteor:mocha

--- a/tests/client/unit/meteor-observable.spec.ts
+++ b/tests/client/unit/meteor-observable.spec.ts
@@ -1,6 +1,6 @@
 import {chai} from 'meteor/practicalmeteor:chai';
 import {sinon} from 'meteor/practicalmeteor:sinon';
-import {MeteorObservable} from "angular2-meteor";
+import {MeteorObservable, ObservableMeteorSubscription} from "angular2-meteor";
 import {Observable} from "rxjs";
 
 const expect = chai.expect;
@@ -93,17 +93,6 @@ describe('MeteorObservable', function () {
       });
     });
 
-    it("Should call RxJS Observable 'complete' callback when subscription is ready", function(done) {
-      let spy = sinon.spy();
-
-      let subscriptionHandler = MeteorObservable.subscribe("test").subscribe(function() {}, function() {}, () => {
-        spy();
-        expect(spy.callCount).to.equal(1);
-        subscriptionHandler.unsubscribe();
-        done();
-      });
-    });
-
     it("Should stop the Meteor subscription when unsubscribing to the RxJS Observable", function(done) {
       function getSubscriptionsCount() {
         return Object.keys((<any>Meteor).default_connection._subscriptions).length;
@@ -114,6 +103,23 @@ describe('MeteorObservable', function () {
       let subscriptionHandler = MeteorObservable.subscribe("test").subscribe(() => {
         expect(getSubscriptionsCount()).to.equal(baseSubscriptionsCount + 1);
         subscriptionHandler.unsubscribe();
+        expect(getSubscriptionsCount()).to.equal(baseSubscriptionsCount);
+        done();
+      });
+    });
+
+
+    it("Should stop the Meteor subscription when calling stop of the Observable", function(done) {
+      function getSubscriptionsCount() {
+        return Object.keys((<any>Meteor).default_connection._subscriptions).length;
+      }
+
+      let baseSubscriptionsCount = getSubscriptionsCount();
+
+      let obs : ObservableMeteorSubscription<any> = MeteorObservable.subscribe("test");
+      let subscriptionHandler = obs.subscribe(() => {
+        expect(getSubscriptionsCount()).to.equal(baseSubscriptionsCount + 1);
+        obs.stop();
         expect(getSubscriptionsCount()).to.equal(baseSubscriptionsCount);
         done();
       });


### PR DESCRIPTION
…Cursor with additional methods

@Hongbo-Miao @Urigo @kamilkisiela @barbatus 

Changes made:
- Added `ObservableMeteorSubscription` as return value for `MeteorObservable.subscribe` with API for stopping the subscription manually (`.stop()`).
Example:
```
// Create new Observable
let observable = MeteorObservable.subscribe("myPub");

// Subscribe to the data (or use ngrx effects)
observable.subscribe(...);

// Stops the MeteorSubscription using the original Meteor's SubscriptionHandler
observable.stop();
```

- Added `ObservableCursor` as return value for `.find({})` with API for creating non-reactive `Observable` by using `.nonReactive()` and API for reloading non-reactive manually by using `.reload()`.
Example:
```
// Create non-reactive
let observable = MyCollection.find({}).nonReactive();

// Trigger Mongo Cursor fetch() and calls next() of the Subscription
observable.reload();
```

Both `ObservableMeteorSubscription` and `ObservableCursor` inherits from RxJS `Observable` so you can use it without any changes in your code. 
